### PR TITLE
Auto-deploy Javadoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+# GitHub Pages deploy action structure based on https://github.com/simonesestito/wasaphoto/blob/master/.github/workflows/public-openapi-docs.yml
+
+name: Deploy Javadoc
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Generate javadoc
+        run:  gradle dokkaHtmlMultiModule
+      - name: Redirect to the submodule directly
+        run:  echo "PCFET0NUWVBFIGh0bWw+PGh0bWw+PGhlYWQ+PG1ldGEgaHR0cC1lcXVpdj0iUmVmcmVzaCIgY29udGVudD0iMDsgdXJsPSd0YXN0aWNhbGVuZGFyL2luZGV4Lmh0bWwnIiAvPjwvaGVhZD48Ym9keT48L2JvZHk+PC9odG1sPgo=" | base64 -d > ./build/dokka/htmlMultiModule/index.html
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload public docs folder
+          path: 'build/dokka/htmlMultiModule/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ on:
       - master
 
 jobs:
-  publish:
+  javadoc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project sources

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ A simple library, based on Material You, to implement a monthly or yearly calend
 
 <p align='center'>
   <a href='https://github.com/m-i-n-a-r/birday/blob/master/LICENSE.md'><img src='https://img.shields.io/badge/license-GPL 3-333333'/></a>
-  <a href="(https://jitpack.io/#m-i-n-a-r/tasticalendar"><img src="https://jitpack.io/v/m-i-n-a-r/tasticalendar.svg" /></a>
+  <a href="https://jitpack.io/#m-i-n-a-r/tasticalendar"><img src="https://jitpack.io/v/m-i-n-a-r/tasticalendar.svg" /></a>
+  <a href="https://m-i-n-a-r.github.io/tasticalendar/">
+  <img alt="Javadoc" src="https://img.shields.io/badge/Read%20the%20documentation-7F52FF?logo=readthedocs&logoColor=white" />
+  </a>
 </p>
+
+[Read the docs!](https://m-i-n-a-r.github.io/tasticalendar/)
 
 ## Introduction
 I wrote this library starting from a piece of [Birday](https://www.github.com/m-i-n-a-r/birday), since i noticed that there isn't a similar library (at least, not a recent one). I kept it super simple and light, but I'm open to any pull request. 

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,5 @@ plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20-Beta' apply false
+    id 'org.jetbrains.dokka' version '1.8.10'
 }

--- a/tasticalendar/build.gradle
+++ b/tasticalendar/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'maven-publish'
+    id 'org.jetbrains.dokka'
 }
 
 android {


### PR DESCRIPTION
Every time a push occurs, deploy updated javadoc using GitHub Pages.

Docs **will** be available at: https://m-i-n-a-r.github.io/tasticalendar/

A preview is currently hosted at https://simonesestito.github.io/tasticalendar/

## GitHub Pages settings
In order to let it work properly, the GitHub Pages source must be set to "GitHub Actions" as in the following screenshot
![image](https://user-images.githubusercontent.com/24279760/223428883-01b6c3c0-02cd-4664-b9ba-bddd260afd96.png)
